### PR TITLE
Implement default constructor for arrays

### DIFF
--- a/src/movingAvg.cpp
+++ b/src/movingAvg.cpp
@@ -11,6 +11,13 @@ void movingAvg::begin()
     m_readings = new int[m_interval];
 }
 
+void movingAvg::begin(int interval)
+{
+    reset();
+    m_interval = interval;
+    m_readings = new int[m_interval];
+}
+
 // add a new reading and return the new moving average
 int movingAvg::reading(int newReading)
 {

--- a/src/movingAvg.h
+++ b/src/movingAvg.h
@@ -11,7 +11,10 @@ class movingAvg
     public:
         movingAvg(int interval)
             : m_interval(interval), m_nbrReadings(0), m_sum(0), m_next(0) {}
+        movingAvg()
+            : m_interval(1), m_nbrReadings(0), m_sum(0), m_next(0) {}
         void begin();
+        void begin(int interval);
         int reading(int newReading);
         int getAvg();
         void reset();


### PR DESCRIPTION
I'd like to use an array of multiple movingAvg objects for multiple analog inputs. So I've added a default constructor and movingAvg::begin(int interval) which can be used for initializing the objects in the ::setup() function.