### PR TITLE
Update library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=A simple Arduino library for calculating moving averages.
 paragraph=Useful for smoothing sensor readings, etc. For efficiency, the library operates in the integer domain; therefore the moving average calculation is approximate.
 category=Data Processing
 url=https://github.com/JChristensen/movingAvg
-architectures=avr
+architectures=*


### PR DESCRIPTION
Although there is no architecture-dependent code in the movingAVG library, having architectures=avr in library.properties causes the library to generate a warning during compilation on other architectures, and the library is marked as INCOMPATIBLE when the board selected is not an AVR board.
Changing architectures=avr to architectures=* solves this.