### PR TITLE
Fix off by one error

### DIFF
--- a/src/movingAvg.h
+++ b/src/movingAvg.h
@@ -6,24 +6,26 @@
 #ifndef MOVINGAVG_H_INCLUDED
 #define MOVINGAVG_H_INCLUDED
 
-class movingAvg
-{
-    public:
-        movingAvg(int interval)
-            : m_interval{interval}, m_nbrReadings{0}, m_sum{0}, m_next{0} {}
-        void begin();
-        int reading(int newReading);
-        int getAvg();
-        int getAvg(int nPoints);
-        int getCount() {return m_nbrReadings;}
-        void reset();
-        int* getReadings() {return m_readings;}
+class movingAvg {
+public:
+    movingAvg(int intervalSize); // Constructor
+    ~movingAvg();                // Destructor
+    void begin();
+    int reading(int newReading);
+    int getAvg();
+    int getAvg(int nPoints);
+    int getCount() const { return numReadings; }
+    void reset();
+    int* getReadingsArray() const { return readings; }
+    void getReadings(int* outArray, int maxSize) const;
 
-    private:
-        int m_interval;     // number of data points for the moving average
-        int m_nbrReadings;  // number of readings
-        long m_sum;         // sum of the m_readings array
-        int m_next;         // index to the next reading
-        int* m_readings;    // pointer to the dynamically allocated interval array
+private:
+    int interval;       // Number of data points for the moving average
+    int numReadings;    // Number of readings
+    long totalSum;      // Sum of the readings array
+    int nextIndex;      // Index to the next reading
+    int* readings;      // Pointer to the dynamically allocated interval array
 };
-#endif
+
+#endif // MOVINGAVG_H_INCLUDED
+


### PR DESCRIPTION
Hi,

I found that after issuing a .reset() there was some sort of off-by-one error. For example using an average of 4 elements, it'd sum the last 5 inputs and divide by 4. I rewrote a bunch of the logic, so it's understandable if you dont want to merge this, figured I'd just submit the PR and you can do what you want with it. 

Cheers. 