### PR TITLE
Fix potential divide by zero

### DIFF
--- a/src/movingAvg.cpp
+++ b/src/movingAvg.cpp
@@ -32,7 +32,10 @@ int movingAvg::reading(int newReading)
 // just return the current moving average
 int movingAvg::getAvg()
 {
-    return (m_sum + m_nbrReadings / 2) / m_nbrReadings;
+    if (m_nbrReadings)
+        return (m_sum + m_nbrReadings / 2) / m_nbrReadings;
+    else
+        return 0;
 }
 
 // return the average for a subset of the data, the most recent nPoints readings.


### PR DESCRIPTION
If you call getAvg() before any readings have been added, a divide by zero occurs.

This can happen on startup if a device is polled for its data before it has had a chance to take any.